### PR TITLE
fix: correct utils import path in Skeleton and Switch components

### DIFF
--- a/.changeset/blue-cherries-complain.md
+++ b/.changeset/blue-cherries-complain.md
@@ -1,0 +1,5 @@
+---
+"@ander-rentcars/ui": patch
+---
+
+Fix utils import in new components

--- a/packages/ui/src/components/skeleton.tsx
+++ b/packages/ui/src/components/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@ander-rentcars/lib/utils"
+import { cn } from "@ander-rentcars/ui/lib/utils"
 
 function Skeleton({
   className,

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
-import { cn } from "@ander-rentcars/lib/utils"
+import { cn } from "@ander-rentcars/ui/lib/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,


### PR DESCRIPTION
This pull request includes changes to fix the import paths for utility functions in new components within the `@ander-rentcars/ui` package.

### Import Path Fixes:

* [`.changeset/blue-cherries-complain.md`](diffhunk://#diff-acf7a82a3371ec740aac43f8a8fcbb3490ecf0ebdf1089772f8dacbd19a9f041R1-R5): Added a changeset entry to document the patch fixing the utils import in new components.
* [`packages/ui/src/components/skeleton.tsx`](diffhunk://#diff-a434b75018ba36babbac0a31d0b2d6d2038439927bd19eaeb60a584cfa94bf54L1-R1): Updated the import path for the `cn` utility function from `@ander-rentcars/lib/utils` to `@ander-rentcars/ui/lib/utils`.
* [`packages/ui/src/components/switch.tsx`](diffhunk://#diff-b652e5e55921b442f2d9bacbb412773bd06e21a1f589e9e7a16cf2040d7007ccL4-R4): Updated the import path for the `cn` utility function from `@ander-rentcars/lib/utils` to `@ander-rentcars/ui/lib/utils`.